### PR TITLE
fix: fixing words in portuguese

### DIFF
--- a/languages/pt.json
+++ b/languages/pt.json
@@ -1,12 +1,12 @@
 {
-	"ASK": "Oque voce gostaria de assitir: ",
+	"ASK": "Oque voce gostaria de assistir: ",
 	"EXIT": "Sair",
-	"SEARCHA": "Pesquisar novamente",
+	"SEARCHA": "Pesquisar Novamente",
 	"DOWNLOAD": "Baixar",
 	"SPROVIDER": "Trocar Provedor",
-	"DSHOW": "Baixar mostrador",
+	"DSHOW": "Baixar serie",
 	"DSEASON": "Baixar Temporada",
 	"SEASON": "Temporada",
 	"EPISODE": "Episodio",
-	"CHANGE": "Trocar Lingua"
+	"CHANGE": "Trocar Idioma"
 }


### PR DESCRIPTION
In this Pull Request, I fixed two issues found in the pt.json file, which is used to provide translations in Portuguese for a certain project. The first problem was a typo in the "ASK" key, which should have the word "assistir", but was written as "assitir". I corrected the typo by adding the missing letter "s".

The second problem was a misinterpretation on my part in the "DSHOW" key. I had mistakenly used the word "mostrador" instead of "serie". I corrected this mistake by replacing the incorrect word with the correct one.

I also change the "CHANGE" key from "Lingua" to "Idioma" , this was not an fix because "Linguage is often of times correctly inpreted but "Idioma" keeps more natural for us that speak in portuguese

Both of these changes have been made and are ready for use. I apologize for my mistake and hope that these corrections improve the quality of the translation file.